### PR TITLE
Fix the publish-record function so that it sends edn

### DIFF
--- a/src/fluree/kinesis/stream.clj
+++ b/src/fluree/kinesis/stream.clj
@@ -63,7 +63,7 @@
                                       (.partitionKey ledger-name)
                                       (.streamName stream-name)
                                       (.data (-> data
-                                                 json/stringify
+                                                 pr-str
                                                  SdkBytes/fromUtf8String))
                                       .build)]
     (try

--- a/src/fluree/kinesis/stream.clj
+++ b/src/fluree/kinesis/stream.clj
@@ -1,6 +1,5 @@
 (ns fluree.kinesis.stream
   (:require [donut.system :as ds]
-            [fluree.db.util.json :as json]
             [fluree.db.util.log :as log])
   (:import (java.util.concurrent ExecutionException)
            (software.amazon.awssdk.core SdkBytes)


### PR DESCRIPTION
This is the fix implemented in commit
57a1f8ef50b7a797db8f9e79760188d9d65accde on the nexus query server repo